### PR TITLE
Sendfile, #10, prevent php files from being downloaded

### DIFF
--- a/conf/apt/dotdeb.list
+++ b/conf/apt/dotdeb.list
@@ -1,5 +1,8 @@
 deb http://packages.dotdeb.org squeeze all
 deb-src http://packages.dotdeb.org squeeze all
 
-deb http://packages.dotdeb.org squeeze-php54 all
-deb-src http://packages.dotdeb.org squeeze-php54 all
+# Uncomment if you need php5.4 - since `apt-get update` runs upon every boot
+# this might end up breaking your vagrant box
+#
+# deb http://packages.dotdeb.org squeeze-php54 all
+# deb-src http://packages.dotdeb.org squeeze-php54 all

--- a/conf/nginx/default
+++ b/conf/nginx/default
@@ -1,5 +1,6 @@
 server {
     listen   81;
+    sendfile off;
     server_name  localhost;
     access_log   /var/log/nginx/localhost.access.log;
     error_log    /var/log/nginx/localhost.error.log error;
@@ -46,6 +47,15 @@ server {
         fastcgi_buffers 4 256k;
         fastcgi_busy_buffers_size 256k;
         fastcgi_temp_file_write_size 256k;
+    }
+
+# Prevent php files from being downloaded
+    location ~ \.php$ {
+        include /etc/nginx/fastcgi_params;
+        fastcgi_index index.php;
+        if (-f $request_filename) {
+            fastcgi_pass 127.0.0.1:9000;
+        }
     }
 
 ## Disable viewing .htaccess & .htpassword


### PR DESCRIPTION
- Fix second vagrant up that fails (by restricting to PHP 5.3 - added this as a hotfix for #10)
- Prevents php files from being downloaded in nginx
- Added `sendfile off;` in nginx config. This is an issue with vagrant shared folders which ends up serving corrupted files (in my case it was serving corrupted js/css files) - http://docs-v1.vagrantup.com/v1/docs/config/vm/share_folder.html
